### PR TITLE
Fix #3 - Unecessary semi-colon after condition structure in JavaScript

### DIFF
--- a/src/main/java/io/vertx/codetrans/JavaScriptLang.java
+++ b/src/main/java/io/vertx/codetrans/JavaScriptLang.java
@@ -93,7 +93,7 @@ public class JavaScriptLang implements Lang {
   public void renderStatement(StatementModel statement, CodeWriter writer) {
     statement.render(writer);
     // In javascript, conditional structure should not have an ending ;. This generates an empty instruction.
-    if (statement instanceof StatementModel.ExpressionStatement) {
+    if (statement instanceof StatementModel.Expression) {
       writer.append(";\n");
     }
   }

--- a/src/main/java/io/vertx/codetrans/JavaScriptLang.java
+++ b/src/main/java/io/vertx/codetrans/JavaScriptLang.java
@@ -93,7 +93,7 @@ public class JavaScriptLang implements Lang {
   public void renderStatement(StatementModel statement, CodeWriter writer) {
     statement.render(writer);
     // In javascript, conditional structure should not have an ending ;. This generates an empty instruction.
-    if (! (statement instanceof StatementModel.ConditionalStructureModel)) {
+    if (statement instanceof StatementModel.ExpressionStatement) {
       writer.append(";\n");
     }
   }
@@ -291,7 +291,7 @@ public class JavaScriptLang implements Lang {
 
   @Override
   public StatementModel forLoop(StatementModel initializer, ExpressionModel condition, ExpressionModel update, StatementModel body) {
-    return StatementModel.ConditionalStructureModel.render((renderer) -> {
+    return StatementModel.conditional((renderer) -> {
       renderer.append("for (");
       initializer.render(renderer);
       renderer.append("; ");

--- a/src/main/java/io/vertx/codetrans/JavaScriptLang.java
+++ b/src/main/java/io/vertx/codetrans/JavaScriptLang.java
@@ -92,7 +92,10 @@ public class JavaScriptLang implements Lang {
   @Override
   public void renderStatement(StatementModel statement, CodeWriter writer) {
     statement.render(writer);
-    writer.append(";\n");
+    // In javascript, conditional structure should not have an ending ;. This generates an empty instruction.
+    if (! (statement instanceof StatementModel.ConditionalStructureModel)) {
+      writer.append(";\n");
+    }
   }
 
   @Override
@@ -288,7 +291,7 @@ public class JavaScriptLang implements Lang {
 
   @Override
   public StatementModel forLoop(StatementModel initializer, ExpressionModel condition, ExpressionModel update, StatementModel body) {
-    return StatementModel.render((renderer) -> {
+    return StatementModel.ConditionalStructureModel.render((renderer) -> {
       renderer.append("for (");
       initializer.render(renderer);
       renderer.append("; ");

--- a/src/main/java/io/vertx/codetrans/StatementModel.java
+++ b/src/main/java/io/vertx/codetrans/StatementModel.java
@@ -8,13 +8,31 @@ import java.util.function.Consumer;
  */
 public class StatementModel extends CodeModel {
 
+  /**
+   * Creates a {@link StatementModel} for an 'if-then-else' conditional structure.
+   * The returned statement is not an {@link io.vertx.codetrans.StatementModel.ExpressionStatement}.
+   *
+   * @param conditionals the conditionals
+   * @param otherwise    the 'else' part
+   * @return the statement
+   */
   public static StatementModel conditionals(List<ConditionalBlockModel> conditionals, StatementModel otherwise) {
-    return ConditionalStructureModel.render((writer) -> {
-      writer.getLang().renderConditionals(conditionals, otherwise, writer);
-    });
+    return new StatementModel() {
+      @Override
+      public void render(CodeWriter writer) {
+        writer.getLang().renderConditionals(conditionals, otherwise, writer);
+      }
+    };
   }
 
-  public static StatementModel render(Consumer<CodeWriter> c) {
+  /**
+   * Creates a {@link StatementModel} for a conditional structure (for loop, while loop...).
+   * The returned statement is not an {@link io.vertx.codetrans.StatementModel.ExpressionStatement}.
+   *
+   * @param c the code of the structure.
+   * @return the statement
+   */
+  public static StatementModel conditional(Consumer<CodeWriter> c) {
     return new StatementModel() {
       @Override
       public void render(CodeWriter writer) {
@@ -23,8 +41,29 @@ public class StatementModel extends CodeModel {
     };
   }
 
+  /**
+   * Creates an {@link io.vertx.codetrans.StatementModel.ExpressionStatement} from the given code.
+   *
+   * @param c the code
+   * @return the statement
+   */
+  public static StatementModel render(Consumer<CodeWriter> c) {
+    return new ExpressionStatement() {
+      @Override
+      public void render(CodeWriter writer) {
+        c.accept(writer);
+      }
+    };
+  }
+
+  /**
+   * Creates an {@link io.vertx.codetrans.StatementModel.ExpressionStatement} from the given code.
+   *
+   * @param s the code
+   * @return the statement
+   */
   public static StatementModel render(String s) {
-    return new StatementModel() {
+    return new ExpressionStatement() {
       @Override
       public void render(CodeWriter writer) {
         writer.append(s);
@@ -33,28 +72,10 @@ public class StatementModel extends CodeModel {
   }
 
   /**
-   * A class marking conditional structures.
-   * In some language conditional structure requires specific actions (such as in JavaScript where then ending
-   * {@code ;} is not required).
+   * Marker class for the _default_ statement model.
    */
-  public static class ConditionalStructureModel extends StatementModel {
-    public static ConditionalStructureModel render(Consumer<CodeWriter> c) {
-      return new ConditionalStructureModel() {
-        @Override
-        public void render(CodeWriter writer) {
-          c.accept(writer);
-        }
-      };
-    }
-
-    public static StatementModel render(String s) {
-      return new ConditionalStructureModel() {
-        @Override
-        public void render(CodeWriter writer) {
-          writer.append(s);
-        }
-      };
-    }
+  public static class ExpressionStatement extends StatementModel {
 
   }
+
 }

--- a/src/main/java/io/vertx/codetrans/StatementModel.java
+++ b/src/main/java/io/vertx/codetrans/StatementModel.java
@@ -10,7 +10,7 @@ public class StatementModel extends CodeModel {
 
   /**
    * Creates a {@link StatementModel} for an 'if-then-else' conditional structure.
-   * The returned statement is not an {@link io.vertx.codetrans.StatementModel.ExpressionStatement}.
+   * The returned statement is not an {@link Expression}.
    *
    * @param conditionals the conditionals
    * @param otherwise    the 'else' part
@@ -27,7 +27,7 @@ public class StatementModel extends CodeModel {
 
   /**
    * Creates a {@link StatementModel} for a conditional structure (for loop, while loop...).
-   * The returned statement is not an {@link io.vertx.codetrans.StatementModel.ExpressionStatement}.
+   * The returned statement is not an {@link Expression}.
    *
    * @param c the code of the structure.
    * @return the statement
@@ -42,13 +42,13 @@ public class StatementModel extends CodeModel {
   }
 
   /**
-   * Creates an {@link io.vertx.codetrans.StatementModel.ExpressionStatement} from the given code.
+   * Creates an {@link Expression} from the given code.
    *
    * @param c the code
    * @return the statement
    */
   public static StatementModel render(Consumer<CodeWriter> c) {
-    return new ExpressionStatement() {
+    return new Expression() {
       @Override
       public void render(CodeWriter writer) {
         c.accept(writer);
@@ -57,13 +57,13 @@ public class StatementModel extends CodeModel {
   }
 
   /**
-   * Creates an {@link io.vertx.codetrans.StatementModel.ExpressionStatement} from the given code.
+   * Creates an {@link Expression} from the given code.
    *
    * @param s the code
    * @return the statement
    */
   public static StatementModel render(String s) {
-    return new ExpressionStatement() {
+    return new Expression() {
       @Override
       public void render(CodeWriter writer) {
         writer.append(s);
@@ -74,7 +74,7 @@ public class StatementModel extends CodeModel {
   /**
    * Marker class for the _default_ statement model.
    */
-  public static class ExpressionStatement extends StatementModel {
+  public static class Expression extends StatementModel {
 
   }
 

--- a/src/main/java/io/vertx/codetrans/StatementModel.java
+++ b/src/main/java/io/vertx/codetrans/StatementModel.java
@@ -9,7 +9,7 @@ import java.util.function.Consumer;
 public class StatementModel extends CodeModel {
 
   public static StatementModel conditionals(List<ConditionalBlockModel> conditionals, StatementModel otherwise) {
-    return StatementModel.render((writer) -> {
+    return ConditionalStructureModel.render((writer) -> {
       writer.getLang().renderConditionals(conditionals, otherwise, writer);
     });
   }
@@ -30,5 +30,31 @@ public class StatementModel extends CodeModel {
         writer.append(s);
       }
     };
+  }
+
+  /**
+   * A class marking conditional structures.
+   * In some language conditional structure requires specific actions (such as in JavaScript where then ending
+   * {@code ;} is not required).
+   */
+  public static class ConditionalStructureModel extends StatementModel {
+    public static ConditionalStructureModel render(Consumer<CodeWriter> c) {
+      return new ConditionalStructureModel() {
+        @Override
+        public void render(CodeWriter writer) {
+          c.accept(writer);
+        }
+      };
+    }
+
+    public static StatementModel render(String s) {
+      return new ConditionalStructureModel() {
+        @Override
+        public void render(CodeWriter writer) {
+          writer.append(s);
+        }
+      };
+    }
+
   }
 }

--- a/src/test/java/io/vertx/codetrans/ConversionTestBase.java
+++ b/src/test/java/io/vertx/codetrans/ConversionTestBase.java
@@ -69,7 +69,7 @@ public abstract class ConversionTestBase {
     return convert(lang, path).get(method);
   }
 
-  public Map<String, Result> convert(Lang lang, String path) {
+  public static Map<String, Result> convert(Lang lang, String path) {
     try {
       return ConvertingProcessor.convert(ClassIdentifierExpressionTest.class.getClassLoader(), lang, path + ".java");
     } catch (Exception e) {
@@ -77,7 +77,7 @@ public abstract class ConversionTestBase {
     }
   }
 
-  public Script script(Lang lang, String path, String method) {
+  public static Script script(Lang lang, String path, String method) {
     Map<String, Result> results = convert(lang, path);
     Thread current = Thread.currentThread();
     ClassLoader prev = current.getContextClassLoader();

--- a/src/test/java/io/vertx/codetrans/JavaScriptSyntaxTest.java
+++ b/src/test/java/io/vertx/codetrans/JavaScriptSyntaxTest.java
@@ -1,0 +1,47 @@
+package io.vertx.codetrans;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test checking that the generated JavaScript code is compliant with the ECMA specification.
+ */
+public class JavaScriptSyntaxTest {
+
+  @Test
+  public void testThatConditionalStructuresDoNotHaveTrailingSemiColon() throws Exception {
+    JavaScriptLang lang = new JavaScriptLang();
+
+    // For Loop
+    Script script = ConversionTestBase.script(lang, "control/ForLoop", "start");
+    Assert.assertFalse("Unnecessary semicolon after for loop", script.getSource().contains("};"));
+
+    // For Each - it's not a conditional structure, but worth testing.
+    script = ConversionTestBase.script(lang, "control/ForEach", "start");
+    Assert.assertFalse("Unnecessary semicolon after for each loop", script.getSource().contains("};"));
+    Assert.assertTrue("Check embedded lamdba closing for each loop", script.getSource().contains("});"));
+
+    // If Then Else
+    script = ConversionTestBase.script(lang, "control/Conditional", "evalThen");
+    Assert.assertFalse("Unnecessary semicolon after if - then - else structure", script.getSource().contains("};"));
+
+    script = ConversionTestBase.script(lang, "control/Conditional", "skipThen");
+    Assert.assertFalse("Unnecessary semicolon after if - then - else structure", script.getSource().contains("};"));
+
+    script = ConversionTestBase.script(lang, "control/Conditional", "evalThenSkipElse");
+    Assert.assertFalse("Unnecessary semicolon after if - then - else structure", script.getSource().contains("};"));
+
+    script = ConversionTestBase.script(lang, "control/Conditional", "skipThenEvalElse");
+    Assert.assertFalse("Unnecessary semicolon after if - then - else structure", script.getSource().contains("};"));
+
+    script = ConversionTestBase.script(lang, "control/Conditional", "evalThenSkipElseIfSkipElse");
+    Assert.assertFalse("Unnecessary semicolon after if - then - else structure", script.getSource().contains("};"));
+
+    script = ConversionTestBase.script(lang, "control/Conditional", "skipThenEvalElseIfSkipElse");
+    Assert.assertFalse("Unnecessary semicolon after if - then - else structure", script.getSource().contains("};"));
+
+    script = ConversionTestBase.script(lang, "control/Conditional", "skipThenSkipElseIfEvalElse");
+    Assert.assertFalse("Unnecessary semicolon after if - then - else structure", script.getSource().contains("};"));
+  }
+
+}


### PR DESCRIPTION
- Mark conditional structures with a specific class so the renderer can handle them specifically.
- When handling a condition structure, avoid generating the ending `;`

@vietj please review

Signed-off-by: Clement Escoffier clement.escoffier@gmail.com
