### PR TITLE
Add support for null literals in JSON

### DIFF
--- a/src/main/java/io/vertx/codetrans/expression/JsonArrayLiteralModel.java
+++ b/src/main/java/io/vertx/codetrans/expression/JsonArrayLiteralModel.java
@@ -44,6 +44,8 @@ public class JsonArrayLiteralModel extends ExpressionModel {
     switch (methodName) {
       case "add":
         return new JsonArrayLiteralModel(builder, Helper.append(values, argumentModels.get(0)));
+      case "addNull":
+        return new JsonArrayLiteralModel(builder, Helper.append(values, new NullLiteralModel(builder)));
       default:
         throw new UnsupportedOperationException("Method " + method + " not yet implemented");
     }

--- a/src/main/java/io/vertx/codetrans/expression/JsonArrayModel.java
+++ b/src/main/java/io/vertx/codetrans/expression/JsonArrayModel.java
@@ -53,6 +53,11 @@ public class JsonArrayModel extends ExpressionModel {
           writer.renderJsonArrayAdd(expression, argumentModels.get(0));
         });
       }
+      case "addNull": {
+        return builder.render(writer -> {
+          writer.renderJsonArrayAdd(expression, new NullLiteralModel(builder));
+        });
+      }
       default:
         throw unsupported("Method " + method);
     }

--- a/src/main/java/io/vertx/codetrans/expression/JsonObjectLiteralModel.java
+++ b/src/main/java/io/vertx/codetrans/expression/JsonObjectLiteralModel.java
@@ -41,10 +41,12 @@ public class JsonObjectLiteralModel extends ExpressionModel {
   @Override
   public ExpressionModel onMethodInvocation(TypeInfo receiverType, MethodSignature method, TypeInfo returnType, List<ExpressionModel> argumentModels, List<TypeInfo> argumenTypes) {
     String methodName = method.getName();
+    StringLiteralModel name = (StringLiteralModel) argumentModels.get(0);
     switch (methodName) {
       case "put":
-        StringLiteralModel name = (StringLiteralModel) argumentModels.get(0);
         return new JsonObjectLiteralModel(builder, Helper.append(entries, new Member.Single(name.value).append(argumentModels.get(1))));
+      case "putNull":
+        return new JsonObjectLiteralModel(builder, Helper.append(entries, new Member.Single(name.value).append(new NullLiteralModel(builder))));
       default:
         throw new UnsupportedOperationException("Method " + method + " not yet implemented");
     }

--- a/src/main/java/io/vertx/codetrans/expression/JsonObjectModel.java
+++ b/src/main/java/io/vertx/codetrans/expression/JsonObjectModel.java
@@ -28,6 +28,11 @@ public class JsonObjectModel extends ExpressionModel {
           StringLiteralModel name = (StringLiteralModel) argumentModels.get(0);
           writer.renderJsonObjectAssign(expression, name.value, argumentModels.get(1));
         });
+      case "putNull":
+        return builder.render(writer -> {
+          StringLiteralModel name = (StringLiteralModel) argumentModels.get(0);
+          writer.renderJsonObjectAssign(expression, name.value, new NullLiteralModel(builder));
+        });
       case "encodePrettily":
       case "encode": {
         return builder.jsonObjectEncoder(expression);

--- a/src/main/java/io/vertx/codetrans/expression/NullLiteralModel.java
+++ b/src/main/java/io/vertx/codetrans/expression/NullLiteralModel.java
@@ -1,0 +1,35 @@
+package io.vertx.codetrans.expression;
+
+import io.vertx.codetrans.CodeBuilder;
+import io.vertx.codetrans.CodeWriter;
+
+import java.util.List;
+
+/**
+ * @author <a href="mailto:plopes@redhat.com">Paulo Lopes</a>
+ */
+public class NullLiteralModel extends ExpressionModel {
+
+  public NullLiteralModel(CodeBuilder builder) {
+    super(builder);
+  }
+
+  @Override
+  public boolean isStringDecl() {
+    return true;
+  }
+
+  @Override
+  void collectParts(List<Object> parts) {
+    parts.add(null);
+  }
+
+  public java.lang.String getValue() {
+    return null;
+  }
+
+  @Override
+  public void render(CodeWriter writer) {
+    writer.renderNullLiteral();
+  }
+}

--- a/src/test/java/io/vertx/codetrans/JsonTest.java
+++ b/src/test/java/io/vertx/codetrans/JsonTest.java
@@ -342,4 +342,19 @@ public class JsonTest extends ConversionTestBase {
       o = null;
     });
   }
+
+  @Test
+  public void testJsonArrayAddNull() {
+    JsonArray expected = new JsonArray().addNull();
+    runAll("json/JsArray", "addNull", () -> {
+      Assert.assertEquals(expected, o);
+    });
+  }
+
+  @Test
+  public void testJsonObjectPutNull() {
+    runAll("json/JsObject", "putNull", () -> {
+      Assert.assertEquals(new JsonObject().putNull("foo"), o);
+    });
+  }
 }

--- a/src/test/resources/json/JsArray.java
+++ b/src/test/resources/json/JsArray.java
@@ -149,4 +149,12 @@ public class JsArray {
     JsonArray arr = new JsonArray().add("foo").add("bar");
     JsonTest.o = arr.encode();
   }
+
+  @CodeTranslate
+  public void addNull() throws Exception {
+    JsonArray arr = new JsonArray();
+    arr.addNull();
+    JsonTest.o = JsonConverter.toJsonArray(arr);
+  }
+
 }

--- a/src/test/resources/json/JsObject.java
+++ b/src/test/resources/json/JsObject.java
@@ -164,4 +164,11 @@ public class JsObject {
     obj = JsonConverter.fromJsonObject(obj);
     JsonTest.o = obj.getJsonArray("foo").encodePrettily();
   }
+
+  @CodeTranslate
+  public void putNull() throws Exception {
+    JsonObject obj = new JsonObject();
+    obj.putNull("foo");
+    JsonTest.o = JsonConverter.toJsonObject(obj);
+  }
 }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes paulo@mlopes.net

This will allow example code that uses `new JsonArray().addNull()` and `new JsonObject.putNull("key")` to be translated.
