### PR TITLE
This patch is required for maven 3.3.9 (which is the default of Fedor…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,11 +163,15 @@
               <resources>
                 <resource>
                   <directory>${project.basedir}/src/test/resources</directory>
-                  <includes>io/**</includes>
+                  <includes>
+                    <include>io/**</include>
+                  </includes>
                 </resource>
                 <resource>
                   <directory>${project.basedir}/src/test/java</directory>
-                  <includes>io/**</includes>
+                  <includes>
+                    <include>io/**</include>
+                  </includes>
                 </resource>
               </resources>
             </configuration>


### PR DESCRIPTION
…a 25) works fine with any other maven