### PR TITLE
Support data object toJson() methods

### DIFF
--- a/src/main/java/io/vertx/codetrans/CodeWriter.java
+++ b/src/main/java/io/vertx/codetrans/CodeWriter.java
@@ -320,6 +320,8 @@ public abstract class CodeWriter implements Appendable {
 
   public abstract void renderToDataObject(JsonObjectModel model, ClassTypeInfo type);
 
+  public abstract void renderDataObjectToJson(IdentifierModel model);
+
   public abstract void renderJsonObjectAssign(ExpressionModel expression, String name, ExpressionModel value);
 
   public abstract void renderDataObjectAssign(ExpressionModel expression, String name, ExpressionModel value);

--- a/src/main/java/io/vertx/codetrans/expression/DataObjectModel.java
+++ b/src/main/java/io/vertx/codetrans/expression/DataObjectModel.java
@@ -36,8 +36,20 @@ public class DataObjectModel extends ExpressionModel {
             DataObjectLiteralModel.unwrapSet(methodName));
       });
     }
+    if (isToJson(method)) {
+      return builder.render(writer -> {
+        writer.renderDataObjectToJson((IdentifierModel) expression);
+      });
+    }
     throw new UnsupportedOperationException("Unsupported method " + method + " on object model");
   }
+
+  private boolean isToJson(MethodSignature method) {
+    return "toJson".equals(method.getName())
+      && method.getReturnType().getKind().json
+      && method.getParameterTypes().isEmpty();
+  }
+
   @Override
   public void render(CodeWriter writer) {
     expression.render(writer);

--- a/src/main/java/io/vertx/codetrans/lang/groovy/GroovyWriter.java
+++ b/src/main/java/io/vertx/codetrans/lang/groovy/GroovyWriter.java
@@ -193,6 +193,11 @@ class GroovyWriter extends CodeWriter {
     renderJsonObject(model.getMembers());
   }
 
+  @Override
+  public void renderDataObjectToJson(IdentifierModel model) {
+    model.render(this);
+  }
+
   public void renderJsonObject(JsonObjectLiteralModel jsonObject) {
     renderJsonObject(jsonObject.getMembers());
   }

--- a/src/main/java/io/vertx/codetrans/lang/js/JavaScriptWriter.java
+++ b/src/main/java/io/vertx/codetrans/lang/js/JavaScriptWriter.java
@@ -10,6 +10,8 @@ import io.vertx.codetrans.expression.*;
 import io.vertx.codetrans.CodeModel;
 import io.vertx.codetrans.CodeWriter;
 import io.vertx.codetrans.MethodSignature;
+import io.vertx.codetrans.TypeArg;
+import io.vertx.codetrans.expression.*;
 import io.vertx.codetrans.statement.StatementModel;
 
 import javax.lang.model.element.TypeElement;
@@ -113,6 +115,11 @@ class JavaScriptWriter extends CodeWriter {
 
   public void renderDataObject(DataObjectLiteralModel model) {
     renderJsonObject(model.getMembers());
+  }
+
+  @Override
+  public void renderDataObjectToJson(IdentifierModel model) {
+    model.render(this);
   }
 
   @Override

--- a/src/main/java/io/vertx/codetrans/lang/kotlin/KotlinCodeWriter.java
+++ b/src/main/java/io/vertx/codetrans/lang/kotlin/KotlinCodeWriter.java
@@ -1,6 +1,9 @@
 package io.vertx.codetrans.lang.kotlin;
 
 import com.sun.source.tree.LambdaExpressionTree;
+import io.vertx.codegen.type.*;
+import io.vertx.codetrans.*;
+import io.vertx.codetrans.expression.*;
 import io.vertx.codegen.type.ApiTypeInfo;
 import io.vertx.codegen.type.ClassTypeInfo;
 import io.vertx.codegen.type.EnumTypeInfo;
@@ -16,14 +19,7 @@ import io.vertx.codetrans.statement.StatementModel;
 import kotlin.collections.CollectionsKt;
 
 import javax.lang.model.element.TypeElement;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -605,6 +601,12 @@ public class KotlinCodeWriter extends CodeWriter {
       unindent();
     }
     append(")");
+  }
+
+  @Override
+  public void renderDataObjectToJson(IdentifierModel model) {
+    model.render(this);
+    append(".toJson()");
   }
 
   @Override

--- a/src/main/java/io/vertx/codetrans/lang/ruby/RubyWriter.java
+++ b/src/main/java/io/vertx/codetrans/lang/ruby/RubyWriter.java
@@ -14,6 +14,9 @@ import io.vertx.codetrans.Helper;
 import io.vertx.codetrans.MethodSignature;
 import io.vertx.codetrans.TypeArg;
 import io.vertx.codetrans.expression.*;
+import io.vertx.codegen.type.*;
+import io.vertx.codetrans.*;
+import io.vertx.codetrans.expression.*;
 import io.vertx.codetrans.statement.ConditionalBlockModel;
 import io.vertx.codetrans.statement.StatementModel;
 
@@ -390,6 +393,11 @@ class RubyWriter extends CodeWriter {
   @Override
   public void renderDataObject(DataObjectLiteralModel model) {
     renderJsonObject(model.getMembers(), this);
+  }
+
+  @Override
+  public void renderDataObjectToJson(IdentifierModel model) {
+    model.render(this);
   }
 
   @Override

--- a/src/main/java/io/vertx/codetrans/lang/scala/ScalaCodeWriter.java
+++ b/src/main/java/io/vertx/codetrans/lang/scala/ScalaCodeWriter.java
@@ -2,11 +2,7 @@ package io.vertx.codetrans.lang.scala;
 
 import com.sun.source.tree.LambdaExpressionTree;
 import io.vertx.codegen.type.*;
-import io.vertx.codetrans.CodeBuilder;
-import io.vertx.codetrans.CodeModel;
-import io.vertx.codetrans.CodeWriter;
-import io.vertx.codetrans.MethodSignature;
-import io.vertx.codetrans.TypeArg;
+import io.vertx.codetrans.*;
 import io.vertx.codetrans.expression.*;
 import io.vertx.codetrans.statement.StatementModel;
 
@@ -353,6 +349,12 @@ public class ScalaCodeWriter extends CodeWriter {
     if(dataModelHasMembers) {
       unindent();
     }
+  }
+
+  @Override
+  public void renderDataObjectToJson(IdentifierModel model) {
+    model.render(this);
+    append(".toJson()");
   }
 
   @Override

--- a/src/test/java/io/vertx/codetrans/DataObjectTest.java
+++ b/src/test/java/io/vertx/codetrans/DataObjectTest.java
@@ -5,7 +5,6 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.support.ServerOptions;
 import jdk.nashorn.api.scripting.ScriptObjectMirror;
-import jdk.nashorn.internal.runtime.ScriptObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -194,6 +193,26 @@ public class DataObjectTest extends ConversionTestBase {
 //    o = null;
 //    runScala("dataobject/DataObject", "enumValueFromConstructor");
 //    Assert.assertEquals(new JsonObject().put("protocolVersion", "HTTP_2"), unwrapJsonObject((Map<String, Object>) o));
+  }
+
+  @Test
+  public void testToJson() throws Exception {
+    JsonObject expected = new JsonObject()
+      .put("protocolVersion", "HTTP_2")
+      .put("port", 8080)
+      .put("keyStore", new JsonObject().put("path", "/keystore").put("password", "r00t"));
+    o = null;
+    runJavaScript("dataobject/DataObject", "toJson");
+    Assert.assertEquals(new JsonObject().put("result", expected), unwrapJsonObject((ScriptObjectMirror) o));
+    o = null;
+    runGroovy("dataobject/DataObject", "toJson");
+    Assert.assertEquals(new JsonObject().put("result", expected), unwrapJsonObject((Map<String, Object>) o));
+    o = null;
+    runRuby("dataobject/DataObject", "toJson");
+    Assert.assertEquals(new JsonObject().put("result", expected), unwrapJsonObject((Map<String, Object>) o));
+    o = null;
+//    runScala("dataobject/DataObject", "toJson");
+//    Assert.assertEquals(expected, unwrapJsonObject((Map<String, Object>) o));
   }
 
   @Test

--- a/src/test/java/io/vertx/support/KeyStoreOptions.java
+++ b/src/test/java/io/vertx/support/KeyStoreOptions.java
@@ -37,4 +37,11 @@ public class KeyStoreOptions {
     this.password = password;
     return this;
   }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    if (path != null) jsonObject.put("path", path);
+    if (password != null) jsonObject.put("password", password);
+    return jsonObject;
+  }
 }

--- a/src/test/java/io/vertx/support/ServerOptions.java
+++ b/src/test/java/io/vertx/support/ServerOptions.java
@@ -2,6 +2,7 @@ package io.vertx.support;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.*;
@@ -80,6 +81,19 @@ public class ServerOptions {
   public ServerOptions addHeader(String name, String value) {
     headers.put(name, value);
     return this;
+  }
+
+  public JsonObject toJson() {
+    JsonObject jsonObject = new JsonObject();
+    if (host != null) jsonObject.put("host", host);
+    jsonObject.put("port", port);
+    if (keyStore != null) jsonObject.put("keyStore", keyStore.toJson());
+    if (enabledCipherSuites != null && !enabledCipherSuites.isEmpty())
+      jsonObject.put("enabledCipherSuites", enabledCipherSuites.stream().<JsonArray>collect(JsonArray::new, JsonArray::add, JsonArray::addAll));
+    if (protocolVersion != null) jsonObject.put("protocolVersion", protocolVersion);
+    if (headers != null && !headers.isEmpty())
+      jsonObject.put("headers", headers.entrySet().stream().<JsonObject>collect(JsonObject::new, (obj, entry) -> obj.put(entry.getKey(), entry.getValue()), JsonObject::mergeIn));
+    return jsonObject;
   }
 
   @Override

--- a/src/test/resources/config.json
+++ b/src/test/resources/config.json
@@ -18,6 +18,7 @@
       "dataobject.DataObject#nested",
       "dataobject.DataObject#setFromConstructor",
       "dataobject.DataObject#setFromIdentifier",
+      "dataobject.DataObject#toJson",
       "dataobject.DataObject#jsonObjectConstructor",
       "dataobject.DataObject#literalJsonObjectConstructor",
       "expression.LiteralChar#start",

--- a/src/test/resources/dataobject/DataObject.java
+++ b/src/test/resources/dataobject/DataObject.java
@@ -1,7 +1,7 @@
 package dataobject;
 
-import io.vertx.codetrans.annotations.CodeTranslate;
 import io.vertx.codetrans.DataObjectTest;
+import io.vertx.codetrans.annotations.CodeTranslate;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.json.JsonObject;
 import io.vertx.support.KeyStoreOptions;
@@ -62,6 +62,17 @@ public class DataObject {
     ServerOptions obj = new ServerOptions();
     obj.setProtocolVersion(HttpVersion.HTTP_2);
     DataObjectTest.o = obj;
+  }
+
+  @CodeTranslate
+  public void toJson() throws Exception {
+    JsonObject jsonObject = new JsonObject();
+    ServerOptions serverOptions = new ServerOptions()
+      .setProtocolVersion(HttpVersion.HTTP_2)
+      .setPort(8080)
+      .setKeyStore(new KeyStoreOptions().setPath("/keystore").setPassword("r00t"));
+    jsonObject.put("result", serverOptions.toJson());
+    DataObjectTest.o = jsonObject;
   }
 
   @CodeTranslate


### PR DESCRIPTION
Needed to support examples as the following in `vertx-config`:

```java
JsonObject vault_config = new JsonObject()
  .put("host", "127.0.0.1") // The host name
  .put("port", 8200) // The port
  .put("ssl", true); // Whether or not SSL is used (disabled by default)

// Certificates
PemKeyCertOptions certs = new PemKeyCertOptions()
  .addCertPath("target/vault/config/ssl/client-cert.pem")
  .addKeyPath("target/vault/config/ssl/client-privatekey.pem");
vault_config.put("pemKeyCertOptions", certs.toJson());

// Truststore
JksOptions jks = new JksOptions()
  .setPath("target/vault/config/ssl/truststore.jks");
vault_config.put("trustStoreOptions", jks.toJson());

// Path to the secret to read.
vault_config.put("path", "secret/my-secret");

ConfigStoreOptions store = new ConfigStoreOptions()
  .setType("vault")
  .setConfig(vault_config);

ConfigRetriever retriever = ConfigRetriever.create(vertx,
  new ConfigRetrieverOptions().addStore(store));
```